### PR TITLE
0.2.4: require forwardable before using it

### DIFF
--- a/lib/unicorn_metrics.rb
+++ b/lib/unicorn_metrics.rb
@@ -50,6 +50,7 @@ module UnicornMetrics
 end
 
 require 'raindrops'
+require 'forwardable'
 require_relative 'unicorn_metrics/registry'
 require_relative 'unicorn_metrics/version'
 require_relative 'unicorn_metrics/counter'
@@ -58,5 +59,3 @@ require_relative 'unicorn_metrics/default_http_metrics'
 require_relative 'unicorn_metrics/request_counter'
 require_relative 'unicorn_metrics/request_timer'
 require_relative 'unicorn_metrics/response_counter'
-require 'forwardable'
-

--- a/lib/unicorn_metrics/version.rb
+++ b/lib/unicorn_metrics/version.rb
@@ -1,3 +1,3 @@
 module UnicornMetrics
-  VERSION = '0.2.3'
+  VERSION = '0.2.4'
 end


### PR DESCRIPTION
Ran into a WTF in #hello-world: https://di-tylertech.slack.com/archives/C03UYREHB/p1546637260039100

- [x] Bumped gem version in `lib/unicorn_metrics/version.rb`
- [ ] Ran `bundle install` and updated the `Gemfile.lock` if any `Gemfile` changes were made
- [x] Ran unit tests with `bundle exec rake`
- [ ] Made sure the JIRA ticket ID is in the commit message(s)
